### PR TITLE
Only Import Part of xcoobee-enums Package

### DIFF
--- a/packages/xcoobee-cookie-kit-react/src/CookieKitPopup.js
+++ b/packages/xcoobee-cookie-kit-react/src/CookieKitPopup.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import ReactCountryFlag from "react-country-flag";
-import Enums from "xcoobee-enums";
+import COUNTRY_DATA from "xcoobee-enums/src/lists/country-data";
 
 import {
   cookieDefns as allAvailCookieDefns,
@@ -22,8 +22,6 @@ import { xbOrigin } from "./configs";
 const BLOCK = "xb-cookie-kit-popup";
 
 const OPTION = "loginstatus";
-
-const COUNTRY_DATA = Enums.getEnum("country-data");
 
 export default class CookieKitPopup extends React.PureComponent {
   static propTypes = {


### PR DESCRIPTION
Saves a little over 75kB in minified version.
Full import of xcoobee-enums increased size from 160kB to 283kB.
Partial import xcoobee-enums increases size from 160kB to 208kB.

Note: This PR will become moot after we remove xcoobee-enums which we will be doing very soon.